### PR TITLE
Update config.yml- Changing note on weight

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -244,7 +244,7 @@ collections:
         widget: "string"
       - label: "Weight" 
         name: "weight"
-        hint: (1 - first, 2 - second, etc.)
+        hint: (1 - last fight of tier, 2 - third fight of tier, etc. Must be in reverse order.)
         widget: "number"
       - label: "Tier Weight"
         name: "tier_weight"


### PR DESCRIPTION
The way this works it renders the lowest weight at the right, so the hint for the box has been changed to represent that and hopefully have people put them in reverse order- fight 4 weight 1, fight 3 weight 2, etc. 