### PR TITLE
Update clone link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Make sure you have [hugo extended](https://gohugo.io/getting-started/installing/
 
 ```sh
 # Clone the repository
-git clone --recursive https://github.com/The-Balance-FFXIV/glam.git
+git clone --recursive https://github.com/The-Balance-FFXIV/balance-static.git
 
 # Navigate into it
 cd ./glam/


### PR DESCRIPTION
Link to The-Balance-FFXIV/balance-static (this repo) instead of the theme git submodule