### PR TITLE
Check in changes from running initial setup on clean machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 /public/
 /resources/_gen/
 
+# Hugo's tmp/lock files
+.hugo_build.lock
+
 # Executable may be added to repository
 hugo.exe
 hugo.darwin
@@ -10,4 +13,6 @@ hugo.linux
 
 # MacOS
 **/.DS_Store
+
+# Dependencies
 node_modules

--- a/yarn.lock
+++ b/yarn.lock
@@ -1379,6 +1379,18 @@ postcss@^8.1.6, postcss@^8.2.1, postcss@^8.3.6:
     picocolors "^1.0.0"
     source-map-js "^0.6.2"
 
+prettier-plugin-go-template@^0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-go-template/-/prettier-plugin-go-template-0.0.11.tgz#49439095ac0a3a14f34d5024d628265c7a2b954a"
+  integrity sha512-qtgoEjvbgmcDp9TOqYNgrPrA41s6S1UMyzMqjcxdxQahTX0webWfbamyA/x3XeBFEEJmgXrRAirzJrIVzImsMg==
+  dependencies:
+    ulid "^2.3.0"
+
+prettier@^2.4.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+
 pretty-hrtime@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -1775,6 +1787,11 @@ type-is@~1.6.17, type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+ulid@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/ulid/-/ulid-2.3.0.tgz#93063522771a9774121a84d126ecd3eb9804071f"
+  integrity sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==
 
 universalify@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Running `yarn install` and `hugo server --disableFastRender` on a fresh clone of the repo results in a dirty working dir.

Let's check in these lockfile changes and add `.hugo_build.lock` to the gitignore.