### PR TITLE
Github Workflows: LHF low-risk changes and updates

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,11 +8,11 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
@@ -24,16 +24,16 @@ jobs:
           extended: true
 
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
-          node-version: '14.13'
+          node-version: '14.17'
 
       - name: Install dependencies
         run: |
           yarn
           yarn global add postcss-cli@8.3.1 autoprefixer postcss tailwindcss
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: /tmp/hugo_cache
           key: ${{ runner.os }}-hugomod-${{ hashFiles('**/go.sum') }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
           extended: true
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: '14.17'
 


### PR DESCRIPTION
These are low risk changes; I checked the changelogs of affected actions and there didn't seem to be any incredibly breaking changes. For the rest I kept things as safe as possible (most risky is probably the upgrade to latest ubuntu LTS), but if the workflows pass it's probably fine :tm:.

Will iteratively do more upgrades if interest seems to be there, being on node 20 and hugo latest would be cool. :)


Closes https://github.com/The-Balance-FFXIV/balance-static/issues/2176

Refs https://github.com/The-Balance-FFXIV/balance-static/issues/2273

Tests are run here: https://github.com/Zarthus/balance-static/pull/1, i.e. https://github.com/Zarthus/balance-static/actions/runs/5156804304/jobs/9288311406?pr=1