### PR TITLE
allow unsafe, which allows linebreaks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,3 +58,6 @@ enableRobotsTXT = true
     name = 'Info'
     url = '#'
     weight = 60
+
+[markup.goldmark.renderer]
+  unsafe = true


### PR DESCRIPTION
This configuration will respect linebreaks in markdown

[Here's a link to the documentation](https://gohugo.io/getting-started/configuration-markup/#rendererunsafe), essentially it allows you to add HTML 