### PR TITLE
Update balance-static to support LaTeX

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: '0.119.0'
+          hugo-version: '0.134.2'
           extended: true
 
       - name: Setup node

--- a/config.toml
+++ b/config.toml
@@ -18,6 +18,17 @@ enableRobotsTXT = true
   copyrightMessage = '© SQUARE ENIX CO., LTD. All Rights Reserved | FINAL FANTASY is a registered trademark of Square Enix Holdings Co., Ltd. | All content © their respective authors | The Balance is a non-profit community-owned website.'
 
 [markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+    [markup.goldmark.extensions]
+      [markup.goldmark.extensions.extras]
+        enable = true
+      [markup.goldmark.extensions.passthrough]
+        enable = true
+        [markup.goldmark.extensions.passthrough.delimiters]
+          block = [['\[', '\]'], ['$$', '$$']]
+          inline = [['\(', '\)']]
   [markup.tableOfContents]
     endLevel = 2
     startLevel = 1
@@ -58,6 +69,3 @@ enableRobotsTXT = true
     name = 'Info'
     url = '#'
     weight = 60
-
-[markup.goldmark.renderer]
-  unsafe = true

--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,7 @@ enableRobotsTXT = true
   priority = 0.5
 
 [params]
+  math = true
   maxTierGearsets = 8
   maxUltimateGearsets = 4
   maxGearsets = 12


### PR DESCRIPTION
This follows the guide at https://gohugo.io/content-management/mathematics/ to add support to LaTeX, This has `math` set to true globally, but for opt-out if necessary, the page can set the param 'math' set to false. If set to true, it will process the LaTeX in the LaTeX blocks. 

You can use the following for LaTeX blocks (see https://gohugo.io/content-management/mathematics/#step-4 for examples)
`\[ ... \]` , as well as `$$ ... $$` for block, and `\( ... \)` for inline

This has a pair PR in the glam repo: https://github.com/The-Balance-FFXIV/glam/pull/405

I got this all working locally. See this example screenshot for how it can look: 
![image](https://github.com/user-attachments/assets/f68235b6-a21e-446a-980b-f0f83ed0ea1b)

Hopefully for obvious reasons, I omitted content updates (e.g. the above), and, if this is accepted, will make those afterwards.
