### PR TITLE
patch removal to depopulate ood adv. guide

### DIFF
--- a/content/jobs/casters/summoner/advanced-guide.md
+++ b/content/jobs/casters/summoner/advanced-guide.md
@@ -3,7 +3,7 @@ title: Summoner Advanced Guide
 card_header_image: /img/jobs/smn/advanced.png
 authors:
   - Balance-SMN-Staff
-patch: ""
+patch:
 lastmod: 2024-07-23T03:49:45.489Z
 changelog:
   - date: 2021-11-15T21:19:35.756Z

--- a/content/jobs/melee/reaper/advanced-guide.md
+++ b/content/jobs/melee/reaper/advanced-guide.md
@@ -3,7 +3,7 @@ title: Reaper Advanced Guide
 card_header_image: /img/jobs/rpr/screenshot_5-edit.jpg
 authors:
   - ellunavi
-patch: ""
+patch:
 lastmod: 2024-07-04T02:44:58.224Z
 changelog:
   - date: 2021-11-27T12:55:28.038Z

--- a/content/jobs/tanks/paladin/advanced-guide.md
+++ b/content/jobs/tanks/paladin/advanced-guide.md
@@ -3,7 +3,7 @@ title: Paladin Advanced Guide
 card_header_image: /img/jobs/pld/advanced.png
 authors:
   - nikroulah
-patch: ""
+patch:
 lastmod: 2024-07-14T01:05:24.234Z
 changelog:
   - date: 2021-10-27T17:21:01.212Z


### PR DESCRIPTION
hides summoner/reaper/paladin advanced guide since no content exists, yet patch number is >7.0