### PR TITLE
fetch depth change in gh-pages.yml

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
-          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+          fetch-depth: 1    # fetch-depth:0 is not necessary because lastmod comes from frontmatter and gitlog is not used
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3


### PR DESCRIPTION
the hugo config.toml doesn't use enableGitInfo, and the .lastmod info comes from frontmatter, so this tries using a shallow clone of the last commit rather than the entire repo history to speed up checkout